### PR TITLE
Improve SR542 task reliability

### DIFF
--- a/srsinst/sr860/tasks/setreferencetoexternalwithsr542task.py
+++ b/srsinst/sr860/tasks/setreferencetoexternalwithsr542task.py
@@ -15,23 +15,54 @@ from srsinst.sr542.instruments.keys import Keys as CKeys
 
 class SetRefToExternalWithSR542Task(Task):
     """
-Use the internal frequency of SR542 as reference source. \
-To use the outer track of a blade, connect the outer track \
-reference output connector or inner track for chopping.
-Connect
-Change the reference source of SR860 to the external and .
+This task configures an SR542 to provide an External Reference to an 
+SR860 lock-in, for synchronous detection of a chopped optical signal.
+
+Preconditions:
+1. Establish remote communications with SR860 and SR542 from SRSGUI.
+2. Connect SR542 Outer Ref Out (Inner Ref Out, or Shaft Ref Out) to SR860 External Ref In
+using a BNC cable.
+3. Connect your photodetector to the lock-in input as appropriate for your
+experiment.
+
+Postconditions:
+1. Chopper is configured with:
+Source = Internal Freq
+Internal Frequency = [set by user]
+n/m = 1
+Control = Outer [or set by user]
+Blade Phase = [set by user]
+
+2. Lock-in is configured with
+Source = External
+Trigger = Positive TTL
+Ref Input Impedance = 1 MOhm
+Phase = [set by user]
+Harmonic = [set by user]
+
+The chopper motor will be powered up and the frequency of the
+control target will be monitored until it is phase and frequency locked
+at the setpoint frequency.
+
+Once the chopper has reached frequency and phase lock,
+the chopper's frequency is compared to the frequency detected
+at the lock-in's reference input. If these match within 5%,
+the task is considered successful.
+
+If the motor was initially OFF, the user is prompted if they
+wish to return the motor to a OFF state.
     """
     InstName = 'Lock-in to control'
-    TriggerMode = 'trigger mode'
-    TriggerInput = 'trigger input'
-    Phase = 'phase (degree)'
-    Harmonic = 'harmonic to detect'
+    TriggerMode = 'Trigger mode'
+    TriggerInput = 'Trigger input'
+    Phase = 'Lock-in phase (degrees)'
+    Harmonic = 'Harmonic'
     ChopperName = 'Chopper to control'
-    FrequencySource = 'Frequency source'
-    ControlTarget = 'control target'
-    InternalF = 'internal frequency'
-    BladePhase = 'blade phase'
-
+    FrequencySource = 'Source' #  where does this show up?
+    ControlTarget = 'Control'
+    InternalF = 'Internal frequency'
+    BladePhase = 'Chopper blade phase (degrees)'
+    
     input_parameters = {
         InstName: InstrumentInput(0),
         Phase: CommandInput('ref.phase', Reference.phase),
@@ -39,7 +70,7 @@ Change the reference source of SR860 to the external and .
 
         ChopperName: InstrumentInput(1),
         ControlTarget: CommandInput('config.control_target', Config.control_target),
-        InternalF: CommandInput('config.frequency', Config.frequency),
+        InternalF: CommandInput('config.internal_freq', Config.internal_freq),
         BladePhase: CommandInput('config.phase', Config.phase),
     }
 
@@ -49,64 +80,21 @@ Change the reference source of SR860 to the external and .
         self.lockin = get_sr860(self, self.params[self.InstName])
         self.chopper = get_sr542(self, self.params[self.ChopperName])
 
+        # I would delete this? Why can't they control the Shaft?
         if self.chopper.config.control_target not in (CKeys.INNER, CKeys.OUTER):
             msg = 'Control target should be either "{}" or "{}, NOT "{}".'\
                 .format(CKeys.INNER, CKeys.OUTER, self.params[self.ControlTarget])
             raise ValueError(msg)
 
-    def test(self):
+    def test(self):                            
         self.lockin.ref.reference_source = LKeys.External
         self.lockin.ref.trigger_mode = LKeys.PositiveTTL
         self.lockin.ref.trigger_input = LKeys.R1Meg
 
+        self.chopper.config.multiplier = 1
+        self.chopper.config.divisor = 1
+
         initial_motor_state = self.chopper.operate.motor_state
-
-        # Change the reference source to internal
-        if self.chopper.operate.motor_state == CKeys.ON and self.chopper.config.source != CKeys.INTERNAL:
-            reply = self.ask_question("Is it OK to turn off the chopper \n"
-                                      "to change the reference source to internal?")
-            if not reply:
-                self.logger.info("Aborted not to turn off chopper")
-                return
-            else:
-                self.chopper.operate.motor_state = CKeys.OFF
-                time.sleep(1.0)
-                self.chopper.config.source = CKeys.INTERNAL
-
-            self.logger.info('Turning back on the chopper')
-            self.chopper.operate.motor_state = CKeys.ON
-            time.sleep(3.0)
-
-        chopper_f = lockin_f = 0.0
-        if self.chopper.operate.motor_state == CKeys.OFF:
-            reply = self.ask_question("Is it OK to turn on the chopper \n"
-                                      "to check if the frequencies are matched \n"
-                                      "between lock-in and the chopper?")
-            if reply:
-                self.chopper.operate.motor_state = CKeys.ON
-                time.sleep(3.0)
-
-            control_target = self.chopper.config.control_target
-            chopper_f = self.chopper.operate.frequency_monitor[control_target]
-            while chopper_f < 0.98 * self.params[self.InternalF]:
-                time.sleep(1.0)
-                chopper_f = self.chopper.operate.frequency_monitor[control_target]
-
-            lockin_f = self.lockin.data.value[LKeys.ExternalFrequency]
-
-            self.logger.info('Chopper frequency: {:.3f} Hz Lockin external frequency: {:.3f} Hz'
-                             .format(chopper_f, lockin_f))
-
-            valid = 0.95 < chopper_f / lockin_f < 1.05
-            if not valid:
-                self.ask_question('The external frequency {:3f} not matching with'
-                                  'the chopper {} frequency {:.3f}. Check connections'
-                                  .format(lockin_f, self.params[self.ControlTarget], chopper_f, None))
-
-        if initial_motor_state == CKeys.OFF:
-            reply = self.ask_question("Do you want to turn back off the chopper?")
-            if reply:
-                self.chopper.operate.motor_state = CKeys.OFF
 
         phase = self.lockin.ref.phase
         harmonic = self.lockin.ref.harmonic
@@ -115,9 +103,86 @@ Change the reference source of SR860 to the external and .
 
         self.logger.info('Lock-in reference source is set to {}.'.format(self.lockin.ref.reference_source))
         self.logger.info('Trigger mode: {}, trigger input: {}'.format(trigger_mode, trigger_input))
-
         self.logger.info('Phase: {:.3f} degree, harmonic order to detect: {}'
                          .format(phase, harmonic))
+        
+        # used through test
+        timeout_s = 30
+        dt_s = 1.0
 
+        # Change the reference source to internal        
+        if self.chopper.config.source != CKeys.INTERNAL:
+            if self.chopper.operate.motor_state == CKeys.ON:
+                reply = self.ask_question("Is it OK to turn off the chopper "
+                                        "to change the reference source to internal?")
+                if not reply:
+                    self.logger.info("Aborted.")
+                    return
+                else:
+                    self.chopper.operate.motor_state = CKeys.OFF                   
+
+            t_elapsed_s = 0            
+            while(self.chopper.operate.motor_state == CKeys.ON):
+                time.sleep(1.0)                              
+                t_elapsed_s += dt_s
+
+                if t_elapsed_s > timeout_s:
+                    msg = "Timeout waiting for chopper shut down"
+                    self.logger.error(msg)                
+                    raise ValueError(msg)
+            
+            self.chopper.config.source = CKeys.INTERNAL
+
+        chopper_f = lockin_f = 0.0
+        if self.chopper.operate.motor_state == CKeys.OFF:
+            reply = self.ask_question("Proceed to run chopper motor and "
+                                      "test for frequency match between chopper target "
+                                      "and lock-in reference input?")
+            if reply:
+                self.chopper.operate.motor_state = CKeys.ON                
+
+        control_target = self.chopper.config.control_target        
+        t_elapsed_s = 0        
+        while(True):
+            time.sleep(dt_s)            
+            t_elapsed_s += dt_s
+            chopper_f = self.chopper.operate.frequency_monitor[control_target]
+            freq_locked = self.chopper.status.chopper_condition_bit['FL']
+            phase_locked = self.chopper.status.chopper_condition_bit['PL']
+            if(freq_locked and phase_locked):
+                break
+            if t_elapsed_s > timeout_s:
+                msg = "Timeout waiting for chopper lock"
+                self.logger.error(msg)                
+                raise ValueError(msg)
+
+        t_elapsed_s = 0
+        while(True):
+            time.sleep(dt_s)            
+            t_elapsed_s += dt_s
+            ext_unlock = self.lockin.status.lock_in_bit['UNLK']
+            if(not ext_unlock):
+               break
+            if t_elapsed_s > timeout_s:
+                msg = "Timeout waiting for lock-in Ext lock"
+                self.logger.error(msg)
+                raise ValueError(msg)
+            
+        lockin_f = self.lockin.data.value[LKeys.ExternalFrequency]
+
+        self.logger.info("Chopper frequency: {:.3f} Hz\n"
+                         "Lock-in external frequency: {:.3f} Hz"
+                            .format(chopper_f, lockin_f))
+
+        valid = 0.95 < chopper_f / lockin_f < 1.05
+        if not valid:
+            self.ask_question('Lock-in external frequency {:3f} does not match '
+                                'the chopper {} frequency {:.3f}. Check connections.'
+                                .format(lockin_f, self.params[self.ControlTarget], chopper_f, None), return_type = None)
+
+        if initial_motor_state == CKeys.OFF:
+            reply = self.ask_question("Do you want to stop the chopper motor?")
+            if reply:
+                self.chopper.operate.motor_state = CKeys.OFF                
     def cleanup(self):
         pass


### PR DESCRIPTION
I found some bugs in the SR542 task for the SR860. Tried to improve the reliability of the code but still have several sticking points and questions:

1. How are the "Default" values for input parameters established?
2. The values in the task input parameters are not read in at task startup and sent to the instruments. This only occurs when "Apply" is pressed. So if apply is not pressed, the values stored in self.params could be out-of-sync with the actual instrument configuration.
3. "Stop" needs to be able to force a task exit. This can be challenging with multi-threaded applications (i.e. the "Stop" won't be processed until the `test` returns). If there is a loop in the test code, you can end up waiting forever even though you've pressed "Stop".
Perhaps something like this in srsgui/task/task.py:
```
def delay(self, dt_s):
    if self._keep_running:
        time.sleep(dt_s):
    else:
        raise InterruptedError("Aborted.")
```	

5. Unchecking "capture" boxes and re-capturing doesn't appear to update
6. I suggest an explanation of the "capture" window, e.g. 
	a. Show methods [M]
	b. Show raw cmds <CMD>
8. Not alerted by `raise ValueError`. Can this pop up a message? What is the right way to do so?
